### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python setup.py install ; watson"

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://repl.it/badge/github/TailorDev/Watson
+    :target: https://repl.it/github/TailorDev/Watson
+
 .. image:: https://tailordev.github.io/Watson/img/logo-watson-600px.png
 
 |Build Status| |PyPI Latest Version| |Requires.io|


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.It adds a `.replit` configuration file and a Repl.it badge to the `README`. This will allow viewers of the repository to click the run on Repl.it button and be able to use ddgr inside the Repl.it environment.
You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/Watson).