### PR TITLE
change default lookback period for report, aggregate and log to 7 days

### DIFF
--- a/watson/cli.py
+++ b/watson/cli.py
@@ -480,7 +480,7 @@ _SHORTCUT_OPTIONS_VALUES = {
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in report.")
 @click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption,
-              type=DateTime, default=arrow.now().shift(days=-7),
+              type=DateTime, default=arrow.now().shift(days=-6),
               mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date from when the report should start. Defaults "
               "to seven days ago.")
@@ -767,7 +767,7 @@ def report(watson, current, from_, to, projects, tags, ignore_projects,
 @click.option('-c/-C', '--current/--no-current', 'current', default=None,
               help="(Don't) include currently running frame in report.")
 @click.option('-f', '--from', 'from_', cls=MutuallyExclusiveOption,
-              type=DateTime, default=arrow.now().shift(days=-7),
+              type=DateTime, default=arrow.now().shift(days=-6),
               mutually_exclusive=_SHORTCUT_OPTIONS,
               help="The date from when the report should start. Defaults "
               "to seven days ago.")
@@ -914,7 +914,7 @@ def aggregate(ctx, watson, current, from_, to, projects, tags, output_format,
 @click.option('-r/-R', '--reverse/--no-reverse', 'reverse', default=None,
               help="(Don't) reverse the order of the days in output.")
 @click.option('-f', '--from', 'from_', type=DateTime,
-              default=arrow.now().shift(days=-7),
+              default=arrow.now().shift(days=-6),
               help="The date from when the log should start. Defaults "
               "to seven days ago.")
 @click.option('-t', '--to', type=DateTime, default=arrow.now(),


### PR DESCRIPTION
This attempts to resolve [this issue](https://github.com/TailorDev/Watson/issues/354). By default, the `report` and `aggregate` commands give the previous 8 days, and not 7 as one would expect. I also changed the default for the `log` command for consistency.

This is my first time contributing to something like this, so apologies if I haven't done everything correctly. In particular I'm not sure what is meant by "The pull request should include tests." I ran`tox`, and it passed for 3.6 and 3.9 (the only versions I have installed), but how do I "include" the tests?